### PR TITLE
Fix NullPointerException when forcing a chunk in certain cases

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesLoadedChunkManager.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesLoadedChunkManager.java
@@ -69,7 +69,10 @@ public class FTBUtilitiesLoadedChunkManager implements ForgeChunkManager.Loading
 
 			if (!key.teamId.isEmpty())
 			{
-				ticketMap.put(key, ticket);
+				if (!ticket.getChunkList().isEmpty())
+				{
+					ticketMap.put(key, ticket);
+				}
 
 				for (ChunkPos pos : ticket.getChunkList())
 				{


### PR DESCRIPTION
When a ticket with no forced chunks exists at the time of a server stop, it will be readded to the ticketMap on the next server start, but is never made available to Forge. Therefore, if the `forceChunk()` method tries to add a chunk onto that ticket, it will fail with a NullPointerException, because Forge doesn't know this ticket. The consequence is that the chunk will not be loaded.

This will most likely happen to servers with offline chunkloading disabled. When a player logs off, all chunks will be unforced, leaving an empty ticket behind. On the next server start, this ticket will be loaded from the world inside the `ticketsLoaded()` method. Forge's `forceChunk()` method will never be called however, because no chunks exist that should be forced, therefore the ticket is never handed over to Forge, but added to the ticketMap. Checking if the ticket has chunks before adding it to the ticketMap fixes the issue.